### PR TITLE
Improved implementation for alternating the section colors

### DIFF
--- a/twentysecondcv.cls
+++ b/twentysecondcv.cls
@@ -215,19 +215,19 @@
 
 
 
-%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%
 % Section Color box %
-%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%
 \newcounter{colorCounter}
-\def\@sectioncolor#1#2#3{%
+\def\@sectioncolor#1#2#3{
   {%
-   \round{#1#2#3}{
-      \ifcase\value{colorCounter}%
-        maingray\or%
-        mainblue\or%
-        maingray\or%
-        mainblue\else%
-        maingray\fi%
+  % Switch between blue and gray
+   \round{#1#2#3}{%
+      \ifodd\value{colorCounter}%
+        mainblue%
+      \else%
+        maingray%
+      \fi%
     }%
   }%
   \stepcounter{colorCounter}%


### PR DESCRIPTION
The current implementation for alternating the color of the node
containing the first three characters of the section titles only works
for the first five sections and isn't very elegant either.

See issue #22.